### PR TITLE
Allow JSX in .jsx files

### DIFF
--- a/react.js
+++ b/react.js
@@ -15,7 +15,7 @@ module.exports = {
     'jsx-a11y/label-has-for': 0,
     'jsx-quotes': [2, 'prefer-double'],
     'react/display-name': 2,
-    'react/jsx-filename-extension': ['error', { extensions: ['.js']}],
+    'react/jsx-filename-extension': ['error', { extensions: ['.js', '.jsx'] }],
     'react/jsx-key': 1,
     'react/jsx-no-duplicate-props': [2, { ignoreCase: true }],
     'react/jsx-no-undef': 2,


### PR DESCRIPTION
I tried using this config in the webapp and was met with a "no JSX in
.jsx files."

If we want to allow JSX in .js files that's fine, but this was
implicitly disallowing it in .jsx files.