### PR TITLE
Remove max len

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = {
     'handle-callback-err': 0,
     indent: ['error', 2, { SwitchCase: 1, MemberExpression: 1 }],
     'keyword-spacing': [2, { after: true }],
-    'max-len': ['error', { code: 120 }],
     'new-cap': [2, { capIsNew: false }],
     'no-bitwise': 2,
     'no-cond-assign': [2, 'always'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gsc",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A shareable ESLint configuration from GoSpotCheck",
   "author": "Matt Webb <mattwebb0@gmail.com>",
   "main": "index.js",


### PR DESCRIPTION
removing max-len because we have so many use cases where alls were doing is just adding a bunch of ignore statements